### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Gradle Build
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/rahulsom/nothing/security/code-scanning/1](https://github.com/rahulsom/nothing/security/code-scanning/1)

To address the problem, add an explicit `permissions` block in `.github/workflows/build.yml`. It should ideally be set at the root level to apply to all jobs unless overridden. Since the workflow runs a Gradle build, a safe least-privilege default would be `contents: read` (read access to repository contents). If your build or publishing steps require additional permissions (e.g., writing PRs, publishing releases), you should expand the block as needed. For now, add the minimal `permissions:` block at the top of the workflow file under the `name:`.  
The change should be made in `.github/workflows/build.yml`, inserting the `permissions:` block between the `name:` and `on:` directives.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
