### PR TITLE
chore: Remove markdown file with build scan

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,12 +6,6 @@ develocity {
     buildScan {
         termsOfUseUrl.set("https://gradle.com/terms-of-service")
         termsOfUseAgree.set("yes")
-        buildScanPublished {
-            file("build").mkdirs()
-            file("build/gradle-scan.md").writeText(
-                """Gradle Build Scan - [`${this.buildScanId}`](${this.buildScanUri})"""
-            )
-        }
     }
 }
 


### PR DESCRIPTION
GHA Gradle action natively links to the scan now.
