### PR TITLE
fix: grant packages:write permission for GitHub Packages publishing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,4 +25,4 @@ jobs:
       security-events: write
       actions: read
       contents: read
-      packages: read
+      packages: write


### PR DESCRIPTION
## Summary

- Changes `packages` permission from `read` to `write` so candidate and final builds can publish to GitHub Packages
- No additional secrets needed — `GITHUB_TOKEN` and `GITHUB_ACTOR` are injected automatically by Actions and are already used by the waena plugin for authentication